### PR TITLE
Fix ordered list start from zero bug (#891).

### DIFF
--- a/src/nodes/OrderedList.ts
+++ b/src/nodes/OrderedList.ts
@@ -57,7 +57,8 @@ export default class OrderedList extends Node {
   toMarkdown(state, node) {
     state.write("\n");
 
-    const start = node.attrs.order !== undefined ? node.attrs.order : 1;
+    const order = node.attrs.order;
+    const start = order !== undefined && order !== null ? order : 1;
     const maxW = `${start + node.childCount - 1}`.length;
     const space = state.repeat(" ", maxW + 2);
 


### PR DESCRIPTION
Since "node.attrs.order" can also be null, which cause the starting number to be 0.

So I've add extra condition check for null value so that it can set starting number to 1.